### PR TITLE
feat: add build docker image

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -1,0 +1,38 @@
+name: Docker Image CI
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: get version
+        id: vars
+        run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\/v/}
+
+      - uses: actions/checkout@v4
+
+      - name: set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: set up docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: login ghrc hub
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/douyin:${{ steps.vars.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/douyin:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# syntax = docker/dockerfile:experimental
+FROM --platform=${BUILDPLATFORM:-linux/amd64,linux/arm64} node:20-buster AS builder
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+WORKDIR /src
+COPY ./ ./
+
+# RUN两次方便观察install和build, 也可以用pnpm cache and locked
+RUN pnpm install      
+RUN npm run build
+        
+FROM --platform=${BUILDPLATFORM:-linux/amd64,linux/arm64} ghcr.io/rookie-luochao/nginx-runner:latest
+
+COPY --from=builder /src/dist /app

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+PKG = $(shell cat package.json | grep 'name' | sed -e 's/  "name": "//g' -e 's/",//g')
+VERSION = $(shell cat package.json | grep 'version' | sed -e 's/  "version": "//g' -e 's/",//g')
+
+# 本地测试构建docker镜像建议删掉node_modules，node_modules存在有时会导致报错
+docker-build:
+	docker build . -t $(PKG):$(VERSION)
+
+# 请先创建自己的 buildx driver 实例，请看：https://juejin.cn/post/7296763284647542838
+# 显式指定可执行 docker buildx build --platform linux/amd64,linux/arm64 . -t $(PKG):$(VERSION) --push
+docker-buildx-build:
+	docker buildx build --platform linux/amd64 . -t $(PKG):$(VERSION) --load
+
+docker-run:
+	docker run -d -p 80:80 $(PKG):$(VERSION)
+
+docker-build-run: docker-build docker-run


### PR DESCRIPTION
构建docker镜像，方便docker容器化部署项目

补充：
1. docker镜像推到github container hub
2. 获取github token，最好选择Generate new token (classic)，把权限都够选上，设置token不过期，[设置链接](https://github.com/settings/tokens)，[参考链接](https://rem486.top/web/other/github-personal-access-tokens.html#%E8%83%8C%E6%99%AF)
3. 给当前项目配置github token，因为镜像工作流 ci 文件需要使用它(在项目Actions secrets and variables栏目：新建 GHCR_TOKEN 键，把github token赋值给它)，参考链接：https://docs.github.com/zh/actions/security-guides/automatic-token-authentication
4. docker 镜像一般都需要版本号，所以触发工作流的时机为打 tag 触发 docker 镜像构建